### PR TITLE
RCPCH CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
       - main
       - mbarton/docker-build-sep-25
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -17,6 +21,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - uses: guardian/setup-scala@v1
+      - name: 'Login via Azure CLI'
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: Run CI script
         env:
           AZURE_REGISTRY_NAME: ${{ secrets.AZURE_REGISTRY_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - mbarton/docker-build-sep-25
 
 jobs:
   test:
@@ -16,14 +17,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - uses: guardian/setup-scala@v1
-      - name: Build and Test
-        env:
-          PROUT_GITHUB_APP_CLIENT_ID: ${{ secrets.PROUT_TEST_GITHUB_APP_CLIENT_ID }}
-          PROUT_GITHUB_APP_CLIENT_SECRET: ${{ secrets.PROUT_GITHUB_APP_CLIENT_SECRET }}
-          PROUT_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PROUT_TEST_GITHUB_APP_PRIVATE_KEY }}
-        run: sbt -v test
-      - name: Test Summary
-        uses: test-summary/action@v2
-        if: always()
-        with:
-          paths: "test-results/**/TEST-*.xml"
+      - name: Run CI script
+        # env:
+        #   PROUT_GITHUB_APP_CLIENT_ID: ${{ secrets.PROUT_TEST_GITHUB_APP_CLIENT_ID }}
+        #   PROUT_GITHUB_APP_CLIENT_SECRET: ${{ secrets.PROUT_GITHUB_APP_CLIENT_SECRET }}
+        #   PROUT_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PROUT_TEST_GITHUB_APP_PRIVATE_KEY }}
+        run: s/ci
+      # - name: Test Summary
+      #   uses: test-summary/action@v2
+      #   if: always()
+      #   with:
+      #     paths: "test-results/**/TEST-*.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 on:
   workflow_dispatch:
-  pull_request:
 
   # triggering CI default branch improves caching
   # see https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - mbarton/docker-build-sep-25
 
 permissions:
   id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,17 @@ on:
       - mbarton/docker-build-sep-25
 
 jobs:
-  test:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - uses: guardian/setup-scala@v1
       - name: Run CI script
-        # env:
-        #   PROUT_GITHUB_APP_CLIENT_ID: ${{ secrets.PROUT_TEST_GITHUB_APP_CLIENT_ID }}
-        #   PROUT_GITHUB_APP_CLIENT_SECRET: ${{ secrets.PROUT_GITHUB_APP_CLIENT_SECRET }}
-        #   PROUT_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PROUT_TEST_GITHUB_APP_PRIVATE_KEY }}
+        env:
+          AZURE_REGISTRY_NAME: ${{ secrets.AZURE_REGISTRY_NAME }}
+          AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
+          AZURE_LIVE_APP_NAME: ${{ secrets.AZURE_LIVE_APP_NAME }}
         run: s/ci
       # - name: Test Summary
       #   uses: test-summary/action@v2

--- a/build.sbt
+++ b/build.sbt
@@ -73,3 +73,7 @@ routesImport ++= Seq("com.madgag.scalagithub.model._","com.madgag.playgithub.Bin
 
 Compile/doc/sources := Seq.empty
 Compile/packageDoc/publishArtifact := false
+
+dockerBaseImage := "openjdk:21"
+
+Universal / javaOptions += "-Dpidfile.path=/dev/null"

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -2,12 +2,13 @@
 
     <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <!-- We log to stdout so Azure Container Apps picks it up -->
+    <!-- <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>logs/application.log</file>
         <encoder>
             <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
         </encoder>
-    </appender>
+    </appender> -->
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
@@ -15,9 +16,9 @@
         </encoder>
     </appender>
 
-    <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
+    <!-- <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
         <appender-ref ref="FILE" />
-    </appender>
+    </appender> -->
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <appender-ref ref="STDOUT" />
@@ -34,7 +35,7 @@
 
     <root level="INFO">
         <appender-ref ref="ASYNCSTDOUT" />
-        <appender-ref ref="ASYNCFILE" />
+        <!-- <appender-ref ref="ASYNCFILE" /> -->
     </root>
 
 </configuration>

--- a/s/ci
+++ b/s/ci
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+az acr login --name ${AZURE_REGISTRY_NAME}
+
+sbt docker:publishLocal
+
+# Push to Azure
+azure_tag="${AZURE_REGISTRY_NAME}.azurecr.io/digital-growth-charts-server:${GITHUB_SHA}"
+docker tag prout:1.0-SNAPSHOT ${azure_tag}
+docker push ${azure_tag}
+
+# Deploy to live
+az containerapp revision copy \
+    --name ${AZURE_LIVE_APP_NAME} \
+    --resource-group ${AZURE_RESOURCE_GROUP} \
+    --image ${azure_tag} \
+    --query 'properties.provisioningState'


### PR DESCRIPTION
Customisations to prout for the RCPCH

- CI pipeline to our Azure Container Apps deployment
- Pull up Docker Java base image
  - The default is Java 8 (what year is it?!)
- Disable file based logging as we rely on Azure Container Apps capturing stdout

I've also updated the deployment to use a GitHub app rather than a PAT attached to my account (https://github.com/guardian/prout/pull/141)